### PR TITLE
Prevent Watchdog from killing server if plugins take too long to load.

### DIFF
--- a/PoseidonWatchdog/plugin.yml
+++ b/PoseidonWatchdog/plugin.yml
@@ -1,4 +1,4 @@
 name: PoseidonWatchdog
-version: 1.1
+version: 1.2
 author: moderator_man
 main: com.oldschoolminecraft.pw.PoseidonWatchdog

--- a/PoseidonWatchdog/src/com/oldschoolminecraft/pw/PoseidonWatchdog.java
+++ b/PoseidonWatchdog/src/com/oldschoolminecraft/pw/PoseidonWatchdog.java
@@ -1,26 +1,43 @@
 package com.oldschoolminecraft.pw;
 
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class PoseidonWatchdog extends JavaPlugin
-{
+import java.util.logging.Logger;
+
+public class PoseidonWatchdog extends JavaPlugin {
+    //Basic Plugin Info
+    private static PoseidonWatchdog plugin;
+    private Logger log;
+    private String pluginName;
+    private PluginDescriptionFile pdf;
+    //Plugin Specific
     private WatchDogThread watchdog;
-    
-    public void onEnable()
-    {
-        watchdog = new WatchDogThread(Thread.currentThread());
-        watchdog.start();
-        
-        getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable()
-        {
-            public void run() { watchdog.tickUpdate(); }
-        }, 20, 20);
-        
-        System.out.println("PoseidonWatchdog enabled.");
+
+    public void onEnable() {
+        plugin = this;
+        log = this.getServer().getLogger();
+        pdf = this.getDescription();
+        pluginName = pdf.getName();
+        log.info("[" + pluginName + "] Is Loading, Version: " + pdf.getVersion());
+        //Schedule watchdog creation for once the server starts ticking.
+        //Prevents the watchdog from killing the server if plugins take too long to load.
+        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
+            log.info("[" + pluginName + "] Starting Watchdog Thread");
+            watchdog = new WatchDogThread(Thread.currentThread());
+            watchdog.start();
+            getServer().getScheduler().scheduleSyncRepeatingTask(this, () -> {
+                watchdog.tickUpdate();
+            }, 20, 20);
+        }, 0L);
     }
-    
-    public void onDisable()
-    {
-        System.out.println("PoseidonWatchdog disabled.");
+
+    public void onDisable() {
+        log.info("[" + pluginName + "] Disabling");
+        if (watchdog != null) {
+            log.info("[" + pluginName + "] Watchdog Thread Disabled");
+            watchdog.interrupt();
+        }
     }
 }


### PR DESCRIPTION
Prevent Watchdog from killing server if plugins after Watchdog is loaded take over 30 seconds to load by only starting the watchdog once the first game tick has occurred. Improve logging messages.